### PR TITLE
Now with silly string

### DIFF
--- a/defs.h
+++ b/defs.h
@@ -54,13 +54,13 @@ typedef struct Set
 #define WRITE       2  /* Bus Write */ 
 #define INVALIDATE  3  /* Bus Invalidate */ 
 #define RWIM        4  /* Bus Read With Intent to Modify */ 
- 
+
 /* Snoop Result types */ 
  
 #define NOHIT       0  /* No hit */ 
 #define HIT         1  /* Hit */ 
 #define HITM        2  /* Hit to modified line */ 
- 
+
 /* L2 to L1 message types */ 
  
 #define GETLINE         1  /* Request data for modified line in L1 */ 

--- a/llcmain.c
+++ b/llcmain.c
@@ -13,6 +13,30 @@
 
 #include "defs.h"
 
+/*
+ * Make the debugging more readable
+ */
+const char *BusStr[] = {
+    "NOOP",
+    "READ",
+    "WRITE",
+    "INVALIDATE",
+    "RWIM"
+};
+ 
+const char *SnoopStr[] = {
+    "NOHIT",
+    "HIT",
+    "HITM"
+};
+
+const char *L1Msg[] = {
+    "NOOP",
+    "GETLINE",
+    "SENDLINE",
+    "INVALIDATELINE",
+    "EVICTLINE"
+};
 
 /*
  * Allocate the cache tag array and zero the stats counters.
@@ -53,6 +77,8 @@ void PrintStatistics()
     printf("  Cache writes: %d\n", Writes);
     printf("  Cache hits:   %d\n", Hits);
     printf("  Cache misses: %d\n", Misses);
+    if ((Hits + Misses) == 0) return;
+
     printf("  Hit ratio:    %f\n", Hits / (float)(Hits + Misses));
 }
 
@@ -127,7 +153,8 @@ int BusOperation(int BusOp, unsigned int Address)
 
     if (NormalMode)
     { 
-        printf("BusOp: %d, Address: %x, Snoop Result: %d\n", BusOp, Address, SnoopResult);
+        printf("BusOp: %s, Address: %x, Snoop Result: %s\n",
+                BusStr[BusOp], Address, SnoopStr[SnoopResult]);
     }
     
     return SnoopResult;
@@ -159,7 +186,8 @@ void PutSnoopResult(unsigned int Address, int SnoopResult)
 { 
     if (NormalMode)
     {       
-        printf("SnoopResult: Address %x, SnoopResult: %d\n", Address, SnoopResult); 
+        printf("SnoopResult: Address %x, SnoopResult: %s\n",
+                Address, SnoopStr[SnoopResult]); 
     }
 } 
  
@@ -170,7 +198,7 @@ void MessageToCache(int Message, unsigned int Address)
 { 
     if (NormalMode)
     {       
-        printf("L2: %d %x\n",  Message, Address);
+        printf("L2: %s %x\n", L1Msg[Message], Address);
     }
 }
 


### PR DESCRIPTION
Fixed a bug: forgot to SENDLINE on reads from L1; added strings to debugging output to make it more readable